### PR TITLE
feature/OPS-566 - Upgrading solana mainnet version to v1.10.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/solana:v1.9.29
+FROM solanalabs/solana:v1.10.26
 
 RUN apt-get update && \
     apt-get install --no-install-recommends rustc curl jq -y && \


### PR DESCRIPTION
# This PR:
- [x] Bumps Solana mainnet version

## Comment:
**This minor version change will be tested on dev cluster first and should not be ship to production yet!!**