### PR TITLE
feat: Bumps solana to v1.17.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/solana:v1.17.22
+FROM solanalabs/solana:v1.17.24
 
 RUN apt-get update && \
     apt-get install --no-install-recommends rustc curl jq ca-certificates librust-curl+openssl-probe-dev -y && \


### PR DESCRIPTION
**Hey sweeties, find some friendly contribution in this PR. Miss u all ;)**

## Description
- [x] Bumps Solana version to v1.17.24

## Related Issue

## Motivation and Context
Blockchain Upgrades

## How Has This Been Tested?
```docker
╰─$ docker build -t moraesjeremias/solana:v1.17.24 .
[+] Building 1.2s (7/7) FINISHED                                                                                                                    docker:default
 => => naming to docker.io/moraesjeremias/solana:v1.17.24 
```

[moraesjeremias/solana:v1.17.24](https://hub.docker.com/layers/moraesjeremias/solana/v1.17.24/images/sha256-3d81eb5a6a147df544d1ae480d9874d76caf68fb2f3a118347a35d6e78b1f527?context=repo)

## Screenshots (if appropriate)
