### PR TITLE
Upgrade Solana to 2.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v2.0.14
+FROM anzaxyz/agave:v2.0.15
 
 RUN apt-get update && \
     apt-get install --no-install-recommends rustc curl jq ca-certificates librust-curl+openssl-probe-dev -y && \


### PR DESCRIPTION
- v2.0: Update latest release variable for agave docs (backport of https://github.com/anza-xyz/agave/pull/3220) by @mergify in https://github.com/anza-xyz/agave/pull/3221
- v2.0: runtime: use leader schedule epoch to serve sol_get_epoch_stake (backport of https://github.com/anza-xyz/agave/pull/3279) by @mergify in https://github.com/anza-xyz/agave/pull/3312
- Pin SPL Token CLI version to v4.1.1 by @willhickey in https://github.com/anza-xyz/agave/pull/3344
- Revert - https://github.com/anza-xyz/agave/pull/879 and https://github.com/anza-xyz/agave/pull/768 (v2.0 backport of https://github.com/anza-xyz/agave/pull/3521) by @Lichtso in https://github.com/anza-xyz/agave/pull/3511
- v2.0: Revert "rolls back chained Merkle shreds for testnet downgrade (https://github.com/anza-xyz/agave/pull/3194)" (backport of https://github.com/anza-xyz/agave/pull/3503) by @mergify in https://github.com/anza-xyz/agave/pull/3504
- v2.0: Store epoch in MaxAge (backport of https://github.com/anza-xyz/agave/pull/3485) by @mergify in https://github.com/anza-xyz/agave/pull/3501
- Feature - disable account loader special case by @Lichtso in https://github.com/anza-xyz/agave/pull/3514