### PR TITLE
Bump to v2.0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v1.18.25
+FROM anzaxyz/agave:v2.0.16
 
 RUN apt-get update && \
     apt-get install --no-install-recommends rustc curl jq ca-certificates librust-curl+openssl-probe-dev -y && \


### PR DESCRIPTION
- Bump version to v2.0.16 by @github-actions in https://github.com/anza-xyz/agave/pull/3530
- v2.0: program-runtime: double program cache size (backport of https://github.com/anza-xyz/agave/pull/3481) by @mergify in https://github.com/anza-xyz/agave/pull/3494
- v2.0: Invoke ancient slots shrinking only if skipping rewrites is enabled (backport of https://github.com/anza-xyz/agave/pull/3266) by @mergify in https://github.com/anza-xyz/agave/pull/3580
- v2.0: simplify forward packet batches (backport of https://github.com/anza-xyz/agave/pull/3642) by @mergify in https://github.com/anza-xyz/agave/pull/3648