### PR TITLE
Solana v2.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v2.0.18
+FROM anzaxyz/agave:v2.1.6
 
 RUN apt-get update && \
     apt-get install --no-install-recommends rustc curl jq ca-certificates librust-curl+openssl-probe-dev -y && \


### PR DESCRIPTION
This is a Testnet and Devnet release. It is NOT recommended for Mainnet Beta.

# What's Changed
- v2.1: rekey feature enable_get_epoch_stake_syscall (backport of https://github.com/anza-xyz/agave/pull/3627) by @mergify in https://github.com/anza-xyz/agave/pull/3699
Bump version to v2.1.6 by @github-actions in https://github.com/anza-xyz/agave/pull/3995
- v2.1: SVM: fix executor metrics accumulation in program loader (backport of https://github.com/anza-xyz/agave/pull/3695) by @mergify in https://github.com/anza-xyz/agave/pull/3767
- v2.1: use trailing_zeros for threadset iteration (backport of https://github.com/anza-xyz/agave/pull/3871) by @mergify in https://github.com/anza-xyz/agave/pull/3897
- v2.1: fix audit (backport of https://github.com/anza-xyz/agave/pull/4014) by @mergify in https://github.com/anza-xyz/agave/pull/4022
- v2.1: Rekey direct mapping feature (backport of https://github.com/anza-xyz/agave/pull/4058) by @mergify in https://github.com/anza-xyz/agave/pull/4062
- v2.1: Update docs URL in docusaurus config (backport of https://github.com/anza-xyz/agave/pull/4081) by @mergify in https://github.com/anza-xyz/agave/pull/4087