### PR TITLE
Critical patch 2.1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v2.2.11
+FROM anzaxyz/agave:v2.1.21
 
 # Install dependencies
 RUN apt-get update && \
@@ -9,6 +9,6 @@ RUN apt-get update && \
 # Download and unpack yellowstone-grpc (solana geyser plugin)
 RUN mkdir -p /opt/yellowstone-grpc && \
     curl -L -o /tmp/yellowstone-grpc.tar.bz2 \
-      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v6.0.0+solana.2.2.4/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
+      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v5.0.1+solana.2.1.16/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
     tar -xjf /tmp/yellowstone-grpc.tar.bz2 -C /opt/yellowstone-grpc --strip-components=1 && \
     rm /tmp/yellowstone-grpc.tar.bz2


### PR DESCRIPTION
https://discord.com/channels/428295358100013066/669406841830244375/1362895749506924727

https://docs.google.com/document/d/e/2PACX-1vRPkcQqpXQ6HtMc2uSZVUYX-alg0dW2JOOsC7U4xRlBk1fMt1AaDk_ojoB9FPqfz1QH5ACp2zw83TnZ/pub

```
A critical patch is available for mainnet-beta. If you are comfortable building from source, please follow the instructions below. 

Instructions for building from source:  https://docs.google.com/document/d/e/2PACX-1vRPkcQqpXQ6HtMc2uSZVUYX-alg0dW2JOOsC7U4xRlBk1fMt1AaDk_ojoB9FPqfz1QH5ACp2zw83TnZ/pub

If you are unable to build from source, please wait for v2.1.21 binaries, which will be announced through the usual channels soon.

To verify this message, you can compute the following SHA:

cat <<EOF | shasum -a 256
2025-04-18 -- SOL-2721VSZSd
i affirm that the SECOND ROUND of urgent communication
that you have received from solana foundation or jito
is legitimate
EOF

Expected hash: 62ae7a89f60955917fdc3ef9f134b5c38a2587968cc0fffdfc900961318e1872

Places where the SHA256 is shared:
https://x.com/claudijd/status/1913062956448838017
https://x.com/trentdotsol/status/1913062160798007457
https://github.com/tigarcia
https://x.com/TimGarcia0/status/1913063566099587563
https://x.com/bw_solana/status/1913066274873041051?s=46
```