### PR TITLE
Upgrade devnet to 2.2.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v2.2.12
+FROM anzaxyz/agave:v2.2.14
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
https://github.com/anza-xyz/agave/releases/tag/v2.2.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the base Docker image to a newer version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->