### PR TITLE
chore(geyser): upgrade geyser for solana 2.2.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN apt-get update && \
 # Download and unpack yellowstone-grpc (solana geyser plugin)
 RUN mkdir -p /opt/yellowstone-grpc && \
     curl -L -o /tmp/yellowstone-grpc.tar.bz2 \
-      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v6.0.0+solana.2.2.12/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
+      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v6.1.0+solana.2.2.14/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
     tar -xjf /tmp/yellowstone-grpc.tar.bz2 -C /opt/yellowstone-grpc --strip-components=1 && \
     rm /tmp/yellowstone-grpc.tar.bz2


### PR DESCRIPTION
https://github.com/rpcpool/yellowstone-grpc/compare/v6.0.0+solana.2.2.12...v6.1.0+solana.2.2.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated to a newer version of the yellowstone-grpc Solana geyser plugin for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->