### PR TITLE
chore: upgrade solana 2.2.16 yellowstone 7.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v2.2.15
+FROM anzaxyz/agave:v2.2.16
 
 # Install dependencies
 RUN apt-get update && \
@@ -9,6 +9,6 @@ RUN apt-get update && \
 # Download and unpack yellowstone-grpc (solana geyser plugin)
 RUN mkdir -p /opt/yellowstone-grpc && \
     curl -L -o /tmp/yellowstone-grpc.tar.bz2 \
-      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v7.0.0+solana.2.2.15/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
+      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v7.0.0+solana.2.2.16/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
     tar -xjf /tmp/yellowstone-grpc.tar.bz2 -C /opt/yellowstone-grpc --strip-components=1 && \
     rm /tmp/yellowstone-grpc.tar.bz2


### PR DESCRIPTION
Core contributors have identifed a network security issue that requires an urgent response. Please upgrade to one of the below versions when there's less than 5% delinquent stake. Be sure to have time to monitor your node after upgrading it and report any issues to #mb-validators on https://solana.com/discord

https://github.com/anza-xyz/agave/releases/tag/v2.2.16
https://github.com/jito-foundation/jito-solana/releases/tag/v2.2.16-jito
https://github.com/firedancer-io/firedancer/releases/tag/v0.505.20216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the base Docker image and related plugin to version 2.2.16 for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->