### PR TITLE
chore: upgrade v2.2.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v2.2.16
+FROM anzaxyz/agave:v2.2.17
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
The v2.2.17 release is now recommended for general use by MainnetBeta validators.

Please upgrade when there's less than 5% delinquent stake. Be sure you have time to monitor your node after upgrading it and report any issues to #mb-validators on https://solana.com/discord

As of May 2025, Ubuntu 20.04 has reached its End of Life (EOL) for standard support. Due to this, new binaries are now built using Ubuntu 22.04, and are not compatible with Ubuntu 20.04 or earlier.

 If you are still using Ubuntu 20.04, you will need to build the binaries from source.

We recommend upgrading to Ubuntu 22.04 or later for continued compatibility and support.

https://github.com/anza-xyz/agave/releases/tag/v2.2.17