### PR TITLE
chore: upgrade solana 2.3.8 ys 9.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anzaxyz/agave:v2.3.6
+FROM anzaxyz/agave:v2.3.8
 
 # Install dependencies
 RUN apt-get update && \
@@ -9,6 +9,6 @@ RUN apt-get update && \
 # Download and unpack yellowstone-grpc (solana geyser plugin)
 RUN mkdir -p /opt/yellowstone-grpc && \
     curl -L -o /tmp/yellowstone-grpc.tar.bz2 \
-      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v9.0.0+solana.2.3.6/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
+      "https://github.com/rpcpool/yellowstone-grpc/releases/download/v9.0.1+solana.2.3.6-rc1/yellowstone-grpc-geyser-release22-x86_64-unknown-linux-gnu.tar.bz2" && \
     tar -xjf /tmp/yellowstone-grpc.tar.bz2 -C /opt/yellowstone-grpc --strip-components=1 && \
     rm /tmp/yellowstone-grpc.tar.bz2


### PR DESCRIPTION
https://github.com/anza-xyz/agave/compare/v2.3.6...v2.3.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container base image to a newer patch release for improved security, stability, and compatibility.
  * Bumped the bundled Yellowstone gRPC package to a newer version to align with upstream updates and enhance runtime compatibility.
  * No functional changes to application behavior; build and install steps remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->